### PR TITLE
New carriers

### DIFF
--- a/Data/README.md
+++ b/Data/README.md
@@ -1,3 +1,4 @@
 # Data README
 Here is where you should store all of the raw data so that it can be used by the other functions and files in this repository.
 The raw data may be found on Box at (FIXME - INCLUDE LINK HERE)=
+

--- a/Data/README.md
+++ b/Data/README.md
@@ -1,4 +1,20 @@
 # Data README
+
+## Raw Data
 Here is where you should store all of the raw data so that it can be used by the other functions and files in this repository.
-The raw data may be found on Box at (FIXME - INCLUDE LINK HERE)=
+The raw data may be found on Box at 
+
+https://byu.app.box.com/folder/103939543408
+
+## Processed Data
+The raw data was processed in process.m (DataProcessing/process.m) and resulted
+in a .mat file titled "ProcessedResultsFeb2020.mat". Due to size restrictions on Github,
+this .mat file has also been stored on Box. Note that the ProcessedResultsFeb2020.mat
+file is the primary data file used in almost every script.
+
+https://byu.app.box.com/folder/104708439864
+
+(Note that there is an old version of the ProcessedResults .mat on Box as well.
+That version does not use the center 42 carriers, but rather the 42 that were
+determined to be best. It will likely get removed from Box soon, but until then...)
 

--- a/DataAnalysis/GaussianCapacity.m
+++ b/DataAnalysis/GaussianCapacity.m
@@ -1,5 +1,5 @@
 clear; close all;
-% addpath ../Data
+addpath ../Data
 load ProcessedResultsFeb2020.mat;
 
 %% User Controlled Variables (Le Magicke Numerals)

--- a/DataProcessing/Process.m
+++ b/DataProcessing/Process.m
@@ -3,6 +3,8 @@ tic;
 
 addpath('../Data/');
 addpath('../RefSignalFolder/');
+addpath('../Data/RawData');
+addpath('../Data/RawData/matFiles');
 
 inFileNames = ["Twitchell1_empty.mat", "Twitchell1_traffic.mat", ...
     "Jensen2_empty.mat", "Jensen2_traffic.mat", ...
@@ -28,8 +30,10 @@ numCarriers = Nfft;
 numFrames = 100000; %FIXME this number is hard coded. Needs to be changed if different data is read in
 dataSets = zeros(numFiles, numCarriers, numFrames);
 times = NaT(numFiles, numFrames);
+carriersToTrimEachSide = 11; % On EACH side, so 2*this total
 
 for i = 1:numFiles
+    disp('Working on file ' + string(i) + ' at time ' + string(datetime));
     %     tic;
     structContainingData = load(inFileNames(i)); % Load in raw data
     % The data is loaded in as a struct, so the desired array must be
@@ -58,7 +62,7 @@ for i = 1:numFiles
     % for linear, false for dB)
     noiseOnOddCarriers = true;
     
-    isolatedGoodData = RemoveAttenuatedEdges(linearData, noiseOnOddCarriers, true);
+    isolatedGoodData = RemoveAttenuatedEdgeCarriersEvenly(linearData, noiseOnOddCarriers, carriersToTrimEachSide);
     
 %     if i == 1 || i == 2
 %         isolatedGoodData = RemoveAttenuatedEdges(linearData, noiseOnOddCarriers, true);

--- a/DataProcessing/RemoveAttenuatedEdgeCarriersEvenly.m
+++ b/DataProcessing/RemoveAttenuatedEdgeCarriersEvenly.m
@@ -1,0 +1,36 @@
+function goodData = RemoveAttenuatedEdgeCarriersEvenly(data, noiseOnOddCarriers, numTrimOnEachSide)
+    % Removes the edge carriers of a waveform that are attenuated by
+    % hardware. Does this by trimming off a provided number of signal carriers
+    % from each side (also trims off the appropriate number of noise
+    % carriers)
+
+    [carriers, frames] = size(data);
+    
+    % Need to remove equal number of noise and signal carriers, from both
+    % sides. Use a mask to remove the attenuated data while not affecting
+    % the 'good' carriers
+    lowCarrier = 2*numTrimOnEachSide+1;
+    highCarrier = carriers - 2*numTrimOnEachSide;
+    keepCarriers = zeros(carriers, frames);
+    keepCarriers(lowCarrier:highCarrier, :) = 1;
+    
+    goodData = keepCarriers .* data;
+ 
+    % Plots an example showing which carriers were kept, allowing for
+    % visual verification of the result the code found
+    stem(data(:,1));
+    hold on
+    maskedData = zeros(carriers,1);
+    maskedData(lowCarrier:highCarrier,1) = data(lowCarrier:highCarrier,1);
+    stem(maskedData, 'MarkerFaceColor','k');
+    title({'Result from RemoveAttenuatedEdges.m', ...
+        'Plot values are in dB for visual clarity'});
+    hold off
+        
+    % Masks the original data with zeros for everything that is
+    % attentuated, leaving the 'good' carriers untouched
+    keepCarriers = zeros(carriers,frames);
+    keepCarriers(lowCarrier:highCarrier,:) = 1;
+    goodData = keepCarriers .* data;
+end
+

--- a/README.md
+++ b/README.md
@@ -1,35 +1,21 @@
-# MARB Testing:
-**Purpose**: Determine effects of traffic on secrecy capacity.  
-**Location**: MARB, main floor   
-(Note that this branch was made to adjust the way the carriers were used; previously, we used 42 of the 64, but now we plan on the center 32)
+# New Carriers Branch
 
-## Procedure:
-- A transmitter (ADALM-Pluto) was set up on the southern wall of the eastern 
-doors on the ground floor of the MARB, approximately 93 inches off the ground
-- An amplifier was attached to the transmitter (will check type when campus opens)
-- 6 Receivers were set up on desks approximately 30 inches high at varying 
-distances from the transmitter. See marbRxLocations_labeled.pdf for image
-(Note that 2 more were set up on stairs, but the data was unused)
-- A laptop for each receiver was set up in a way that put the receiving antenna
-directly between the laptop camera and the transmitter, which allowed for clear
-identification of line-of-sigh obstructions in the recorded video
-- Each laptop ran date_time_test.py (which generated a .avi video file and a 
-.txt file with timestamps for each video frame) and MarbRx_Feb2020.m (which recorded
-the received signal, and timestamps, in a .mat file)
-- Data was recorded two times: the first when the halls were mostly empty, 
-the second during a class break when there was more traffic. Both scenarios
-lasted for four minutes.
-   
-## Processing:
-(IN PROGRESS
-       
-## Data:
-- Each .mat, .avi, and .txt file can be found on Box at 
-https://byu.app.box.com/folder/103939543408
-  
-## Other:
-- Two other mini-experiments (Donut Capacity: Distance vs Capacity, and
- MarchControlledTests: Obstacle proximity vs capacity) were also done
-during this experiment, and are located in their respective folders
-with ReadMe.md files explaining them more thoroughly.
+## Explanation
+As you may already know, when we broadcast our 64-subcarrier signal, some of
+the edge carriers are attenuated by the hardware. We normally end up throwing
+these out. This time, as we were looking at the way we determined which carriers
+to throw out, we realized that it required full information of the channel 
+characteristics (it was done by averaging all the frames and looking at the 
+noise floor to see when things got attenuated).
 
+Dr. Harrison preferred that we just take the center X carriers, as that would 
+be more like what we would actually to do were we to not have measured the
+whole environment. 
+
+As such, this branch was made to modify the process.m file accordingly.
+
+Interestingly enough, in the end, the old method ended up taking the center 
+42 carriers, anyway. 
+
+In the end, we copied over the working changes to the master branch. This 
+ReadMe will likely never see the light of day...

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 **Purpose**: Determine effects of traffic on secrecy capacity.  
 **Location**: MARB, main floor   
 (Note that this branch was made to adjust the way the carriers were used; previously, we used 42 of the 64, but now we plan on the center 32)
+
 ## Procedure:
 - A transmitter (ADALM-Pluto) was set up on the southern wall of the eastern 
 doors on the ground floor of the MARB, approximately 93 inches off the ground

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MARB Testing:
 **Purpose**: Determine effects of traffic on secrecy capacity.  
 **Location**: MARB, main floor   
-
+(Note that this branch was made to adjust the way the carriers were used; previously, we used 42 of the 64, but now we plan on the center 32)
 ## Procedure:
 - A transmitter (ADALM-Pluto) was set up on the southern wall of the eastern 
 doors on the ground floor of the MARB, approximately 93 inches off the ground


### PR DESCRIPTION
Dr. Harrison preferred that when we process the data, we just take the center X carriers (as opposed to the fancy method that Kalin developed, which requires us to have measured the channel) as that would be more like what we would actually to do were we to not have measured the
whole environment. 

As such, this branch was made to modify the process.m file accordingly. Now it uses a function that merely takes X carriers on each side of the center.

(Interestingly enough, in the end, the old method ended up taking the center 
42 carriers, anyway.)